### PR TITLE
Split dependencies and devDependencies

### DIFF
--- a/default.json
+++ b/default.json
@@ -49,7 +49,7 @@
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "dependencies (non-major)"
-    }
+    },
     {
       "matchPackageNames": ["pnpm"],
       "groupName": "pnpm"


### PR DESCRIPTION
## Description
`dependencies` と `devDependencies` のPRを分ける
group:allNonMajorは一応漏れ防止やバックエンドなどの他パッケージシステムのために残しておく

<!-- プルリクの内容説明 -->

## Reason
影響範囲が違うので
<!-- なぜその変更を入れたいのか -->

## Document URL
https://zenn.dev/sqer/articles/424292c8732c00
<!-- 参考できるドキュメントのURL -->
