### PR TITLE
remove node disabled

### DIFF
--- a/default.json
+++ b/default.json
@@ -16,9 +16,6 @@
     "npm:unpublishSafe"
   ],
   "labels": ["dependencies"],
-  "node": {
-    "enabled": false
-  },
   "rangeStrategy": "bump",
   "platformCommit": true,
   "platformAutomerge": true,
@@ -32,10 +29,6 @@
     "schedule": ["before 3:00 am on the 15th day of the month"]
   },
   "packageRules": [
-    {
-      "matchPackageNames": ["node"],
-      "enabled": false
-    },
     {
       "matchDepTypes": ["peerDependencies"],
       "rangeStrategy": "widen"


### PR DESCRIPTION
## Description
nodeのdisable設定を削除
<!-- プルリクの内容説明 -->

## Reason
もともと
https://justincase.myjetbrains.com/youtrack/issue/ENGAGE-329
https://github.com/justincase-jp/engage/pull/209
のように利用docker image等の対応状況がコントロールできないためdisableにしたようだが、定期的にPRが出たタイミングで調査して対応不能ならcloseすればよく、忘れ去るデメリットの方が大きいため設定を消す
またどうしてもdisableしたい場合は各リポジトリで上書きできる

<!-- なぜその変更を入れたいのか -->

## Document URL

<!-- 参考できるドキュメントのURL -->
