### PR TITLE
ci: npxでなくリポジトリのrenovateを使う

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,6 @@ jobs:
           - default.json
           - renovate-config.json
           - morning.json5
-    env:
-      RENOVATE_CONFIG_FILE: ${{ matrix.file }}
 
     steps:
       - name: Checkout repo
@@ -57,4 +55,4 @@ jobs:
         run: pnpm install
 
       - name: Validate ${{ matrix.file }}
-        run: pnpm test
+        run: pnpm renovate-config-validator ${{ matrix.file }}


### PR DESCRIPTION
## Description
SSIA
<!-- プルリクの内容説明 -->

## Reason
CIで `npm WARN exec The following package was not found and will be installed: renovate@37.5.3` が出ていたので
<!-- なぜその変更を入れたいのか -->

## Document URL

<!-- 参考できるドキュメントのURL -->
