### PR TITLE
feat: rebaseWhen: never

### DIFF
--- a/default.json
+++ b/default.json
@@ -14,6 +14,7 @@
     "workarounds:all",
     "npm:unpublishSafe"
   ],
+  "rebaseWhen": "never",
   "labels": ["dependencies"],
   "rangeStrategy": "bump",
   "platformCommit": true,


### PR DESCRIPTION
## Description
renovate botがデフォルトでrebaseしないようにする
<!-- プルリクの内容説明 -->

## Reason
- なぜかたまに人間のコミットを潰すことがある
- 大抵はup to date設定してあるし、更新担当者がそのときに手動でチェックボックスでrebaseすれば十分
- 無限実行されることがありCIリソースを無駄に使う
  - joinsure-uiでrenovate botの不具合なのか、github actionと無限push合戦になったときがありchromaticで利用料金が跳ね上がった - https://github.com/justincase-jp/joinsure-ui/pull/592
- 1つマージするたびに残りのrenovate PRが全部再実行されてCIリソースを無駄に使う
  - record-clientのgithub actions実行が増えてvercel remote cacheを浪費して利用料金が増えた
  - これもchromaticのsnapshot枠を浪費していた
<!-- なぜその変更を入れたいのか -->

## Document URL

<!-- 参考できるドキュメントのURL -->
