### PR TITLE
fix: 'Unsupported lock file: pnpm-lock.yaml' を修正

### DIFF
--- a/default.json
+++ b/default.json
@@ -35,8 +35,7 @@
     },
     {
       "matchDepTypes": ["devDependencies"],
-      "groupName": "devDependencies",
-      "rangeStrategy": "update-lockfile"
+      "groupName": "devDependencies"
     },
     {
       "matchDepTypes": ["dependencies"],


### PR DESCRIPTION
## Description
devDependenciesの更新がすぐ

```
 ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date with package.json
```

となるのでrangeStrategyを上層で指定してるbumpになるように修正


<!-- プルリクの内容説明 -->

## Reason
https://github.com/justincase-jp/engage/pull/3192
https://github.com/justincase-jp/engage/pull/3202
などでエラーで止まる
<!-- なぜその変更を入れたいのか -->

## Document URL
pnpmは `rangeStrategy=update-lockfile` 非対応らしい
https://zenn.dev/ikemo/articles/renovate-pnpm
<!-- 参考できるドキュメントのURL -->
