### PR TITLE
feat: PR上限数を50に上げる

### DIFF
--- a/default.json
+++ b/default.json
@@ -8,7 +8,6 @@
     ":semanticPrefixFixDepsChoreOthers",
     ":ignoreModulesAndTests",
     ":prHourlyLimitNone",
-    ":prConcurrentLimit20",
     "group:allNonMajor",
     "group:definitelyTyped",
     "workarounds:all",
@@ -20,6 +19,7 @@
   "platformCommit": true,
   "platformAutomerge": true,
   "postUpdateOptions": ["npmDedupe", "pnpmDedupe", "yarnDedupeHighest"],
+  "prConcurrentLimit": 50,
   "major": {
     "automerge": false
   },


### PR DESCRIPTION
## Description
https://docs.renovatebot.com/configuration-options/#prconcurrentlimit を50に上げる
<!-- プルリクの内容説明 -->

## Reason
1. 当番制が導入されれば工数がしっかり確保できるかもしれない（議論中）
https://www.notion.so/justincase/npm-876b2b110ba04525820629d6b1dfec70

1. 以下と同じ目的だけど上限なしは怖い

https://tech.emotion-tech.co.jp/entry/2023/07/27/110000

> 一度に大量のライブラリの新バージョンが公開されたときに、この上限に引っかかると新しいバージョンが出たことに気づかないことがありました。

> Renovate は prConcurrentLimit が制限されているときに priority に応じた順番で PR を作成します。priority を設定してない場合、デフォルトでは https://docs.renovatebot.com/configuration-options/#prpriority にある順番で PR が作成されます。ドキュメントを見るとメジャーがもっとも priority が低いことがわかります。 つまり、上限以上の更新がある場合、メジャーバージョンアップの PR がなかなか作成されず、気づいたときにはメジャーバージョンが 2 つ以上上がっている、なんてケースも発生してしまいます。

> これを防ぐために上限を撤廃しています。
<!-- なぜその変更を入れたいのか -->

## Document URL

<!-- 参考できるドキュメントのURL -->
